### PR TITLE
switch to XUnit

### DIFF
--- a/SampleWpfApplicationTests/MainWindowBindingTests.cs
+++ b/SampleWpfApplicationTests/MainWindowBindingTests.cs
@@ -1,21 +1,20 @@
 ﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SampleWpfApplication;
 using WpfBindingErrors;
 using System.Windows;
+using Xunit;
 
 namespace SampleWpfApplicationTests
 {
-    [TestClass]
     public class MainWindowBindingTests
     {
-        [TestMethod]
+        [StaFact]
         public void MainWindow_Constructor_DoesNotThrow()
         {
             new MainWindow();
         }
 
-        [TestMethod]
+        [StaFact]
         public void MainWindow_HasNoBindingError()
         {
             // NB: this test must fail !
@@ -24,7 +23,7 @@ namespace SampleWpfApplicationTests
 
             using( var listener = new BindingErrorListener())
             {
-                listener.ErrorCatched += msg => Assert.Fail(msg);
+                listener.ErrorCatched += msg => throw new Exception(msg);
 
                 new MainWindow();
             }            

--- a/SampleWpfApplicationTests/SampleWpfApplicationTests.csproj
+++ b/SampleWpfApplicationTests/SampleWpfApplicationTests.csproj
@@ -14,7 +14,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Xunit.StaFact" Version="1.0.37" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I was not able to run the tests in Visual Studio (Edition: Enterprise 2019, Version: 16.7.2).  I got them to run after switching to XUnit and using [XUnit.StaFact](https://github.com/AArnott/Xunit.StaFact).

P.S.
I am very grateful for your project.  I wanted to add a test that fails if there are any binding errors and your use of...
https://github.com/bblanchon/WpfBindingErrors/blob/f9152afc53b12fe693008880cf840ad6a8fea87b/WpfBindingErrors/BindingErrorListener.cs#L23

...seems necessary.  I couldn't any solution without that line.  Furthermore, in all the other sources that I encountered, I didn't see anyone else use that line.

I don't understand how that line helps.