### PR TITLE
Update target frameworks to net8.0 and net48

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,15 +48,12 @@ Each project contains a dedicated README with more detail.
 Supported frameworks
 --------------------
 
-* .NET Core 3.0 🆕
-* .NET Framework 4.6
-* .NET Framework 4.5.2
-* .NET Framework 4.5.1
-* .NET Framework 4.5
-* .NET Framework 4.0
+* .NET 8 (net8.0-windows) 🆕
+* .NET Framework 4.8 (net48) 🆕
 
 Contributors
 ------------
 
 * [Gareth Brown](https://github.com/wonea)
 * [Bruno Juchli](https://github.com/jongleur1983)
+* [David Neale](https://github.com/davidneale)

--- a/SampleWpfApplication/SampleWpfApplication.csproj
+++ b/SampleWpfApplication/SampleWpfApplication.csproj
@@ -2,9 +2,10 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFrameworks>net8.0-windows;net48</TargetFrameworks>
     <RootNamespace>SampleWpfApplication</RootNamespace>
     <UseWPF>true</UseWPF>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SampleWpfApplicationTests/MainWindowBindingTests.cs
+++ b/SampleWpfApplicationTests/MainWindowBindingTests.cs
@@ -9,7 +9,7 @@ namespace SampleWpfApplicationTests
     [TestClass]
     public class MainWindowBindingTests
     {
-        [TestMethod]
+        [STATestMethod]
         public void MainWindow_Constructor_DoesNotThrow()
         {
             new MainWindow();

--- a/SampleWpfApplicationTests/SampleWpfApplicationTests.csproj
+++ b/SampleWpfApplicationTests/SampleWpfApplicationTests.csproj
@@ -2,11 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFrameworks>net8.0-windows;net48</TargetFrameworks>
     <RootNamespace>SampleWpfApplicationTests</RootNamespace>
     <UseWPF>true</UseWPF>
     <ApplicationIcon />
     <StartupObject />
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,7 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.10.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.10.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WpfBindingErrors/README.md
+++ b/WpfBindingErrors/README.md
@@ -1,44 +1,59 @@
 Turn WPF binding errors into exceptions
 =======================================
 
-This project is a reusable assembly that converts WPF binding errors into exceptions.
+A lightweight library that converts WPF binding errors into exceptions, so you can quickly spot errors in the XAML markup and detect them unit tests.
 
-Feel free to include it in your own project.
-    
+![Exception shown in Visual Studio](SampleWpfApplication/Pictures/XamlParseException.png)
+
+All it requires is a single line in your existing code:
+
+```csharp
+public partial class App : Application
+{
+    protected override void OnStartup(StartupEventArgs args)
+    {
+        base.OnStartup(args);
+        
+        // Start listening for WPF binding error.
+        // After that line, a BindingException will be thrown each time
+        // a binding error occurs.
+        BindingExceptionThrower.Attach();
+    }
+}
+```
+
+Installing:
+-----------
+
+With .NET CLI
+
+    > dotnet add package WpfBindingErrors
+
+With Package Manager:
+
+    PM> Install-Package WpfBindingErrors
+
+https://www.nuget.org/packages/WpfBindingErrors
+
+
 Content
 -------
 
- 1. Class `BindingException` is the typed exception thrown when a binding error occurs
- 2. Static class `BindingExceptionThrower` is the one that throws `BindingException`.
- 3. Class `BindingErrorListener` adds a listener to `PresentationTraceSources.DataBindingSource`. It raises the event `ErrorCatched` whenever a binding error occurs.
- 4. Class `ObservableTraceListener` is internal; it's an override of `System.Diagnostics.TraceListener` and it raises the event `TraceCatched` whenever a trace is written.
-     
-See an example in project `SampleWpfApplicationTests` in this repository.
-   
-Class diagram
--------------
-![Class diagram](Pictures/ClassDiagram.png)
+1. [Project WpfBindingError](WpfBindingErrors) is a reusable assembly that listens for binding errors.
+2. [Project SampleWpfApplication](SampleWpfApplication) shows how to throw `BindingException` at **runtime**.
+3. [Project SampleWpfApplicationTests](SampleWpfApplicationTests) shows how to check binding errors in a **unit test project**.
 
-How to use it?
---------------
+Each project contains a dedicated README with more detail.
 
-The simplest way is to use `BindingExceptionThrower` because it handles everything for you:
+Supported frameworks
+--------------------
 
-```csharp
-BindingExceptionThrower.Attach()
-```
-    
-That's all.  
-Once you called `Attach()`, every WPF binding error will raise a `BindingException`.
-See an example in project `SampleWpfApplication` in this repository.
+* .NET 8 (Windows)
+* .NET Framework 4.8
 
-However, if you want to be aware of binding errors without throwing an exception, you can use `BindingErrorListener`  and attach to the `ErrorCatched` event.
+Contributors
+------------
 
-```csharp
-using( var listener = new BindingErrorListener())
-{
-    listener.ErrorCatched += msg => Console.WriteLine("Binding error: {0}", msg);
-
-    // ...do what you want here...
-}
-```
+* [Gareth Brown](https://github.com/wonea)
+* [Bruno Juchli](https://github.com/jongleur1983)
+* [David Neale](https://github.com/davidneale)

--- a/WpfBindingErrors/README.md
+++ b/WpfBindingErrors/README.md
@@ -1,59 +1,44 @@
 Turn WPF binding errors into exceptions
 =======================================
 
-A lightweight library that converts WPF binding errors into exceptions, so you can quickly spot errors in the XAML markup and detect them unit tests.
+This project is a reusable assembly that converts WPF binding errors into exceptions.
 
-![Exception shown in Visual Studio](SampleWpfApplication/Pictures/XamlParseException.png)
-
-All it requires is a single line in your existing code:
-
-```csharp
-public partial class App : Application
-{
-    protected override void OnStartup(StartupEventArgs args)
-    {
-        base.OnStartup(args);
-        
-        // Start listening for WPF binding error.
-        // After that line, a BindingException will be thrown each time
-        // a binding error occurs.
-        BindingExceptionThrower.Attach();
-    }
-}
-```
-
-Installing:
------------
-
-With .NET CLI
-
-    > dotnet add package WpfBindingErrors
-
-With Package Manager:
-
-    PM> Install-Package WpfBindingErrors
-
-https://www.nuget.org/packages/WpfBindingErrors
-
-
+Feel free to include it in your own project.
+    
 Content
 -------
 
-1. [Project WpfBindingError](WpfBindingErrors) is a reusable assembly that listens for binding errors.
-2. [Project SampleWpfApplication](SampleWpfApplication) shows how to throw `BindingException` at **runtime**.
-3. [Project SampleWpfApplicationTests](SampleWpfApplicationTests) shows how to check binding errors in a **unit test project**.
+ 1. Class `BindingException` is the typed exception thrown when a binding error occurs
+ 2. Static class `BindingExceptionThrower` is the one that throws `BindingException`.
+ 3. Class `BindingErrorListener` adds a listener to `PresentationTraceSources.DataBindingSource`. It raises the event `ErrorCatched` whenever a binding error occurs.
+ 4. Class `ObservableTraceListener` is internal; it's an override of `System.Diagnostics.TraceListener` and it raises the event `TraceCatched` whenever a trace is written.
+     
+See an example in project `SampleWpfApplicationTests` in this repository.
+   
+Class diagram
+-------------
+![Class diagram](Pictures/ClassDiagram.png)
 
-Each project contains a dedicated README with more detail.
+How to use it?
+--------------
 
-Supported frameworks
---------------------
+The simplest way is to use `BindingExceptionThrower` because it handles everything for you:
 
-* .NET 8 (Windows)
-* .NET Framework 4.8
+```csharp
+BindingExceptionThrower.Attach()
+```
+    
+That's all.  
+Once you called `Attach()`, every WPF binding error will raise a `BindingException`.
+See an example in project `SampleWpfApplication` in this repository.
 
-Contributors
-------------
+However, if you want to be aware of binding errors without throwing an exception, you can use `BindingErrorListener`  and attach to the `ErrorCatched` event.
 
-* [Gareth Brown](https://github.com/wonea)
-* [Bruno Juchli](https://github.com/jongleur1983)
-* [David Neale](https://github.com/davidneale)
+```csharp
+using( var listener = new BindingErrorListener())
+{
+    listener.ErrorCatched += msg => Console.WriteLine("Binding error: {0}", msg);
+
+    // ...do what you want here...
+}
+```

--- a/WpfBindingErrors/WpfBindingErrors.csproj
+++ b/WpfBindingErrors/WpfBindingErrors.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netcoreapp3.0;net40;net45;net451;net452;net46</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows;net48</TargetFrameworks>
     <RootNamespace>WpfBindingErrors</RootNamespace>
     <UseWPF>true</UseWPF>
     <ApplicationIcon />
@@ -12,7 +12,7 @@
     <Copyright>Copyright © Benoit Blanchon 2013-2019</Copyright>
     <Description>Throw an exception when a WPF Binding error occurs. Get started by adding WpfBindingErrors.BindingExceptionThrower.Attach(); to your WPF application.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageReleaseNotes>Added .NET Core 3.0 support</PackageReleaseNotes>
+    <PackageReleaseNotes>Updated to target .NET 8 and .NET Framework 4.8. These are current LTS versions.</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/bblanchon/WpfBindingErrors</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bblanchon/WpfBindingErrors</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -20,10 +20,13 @@
     <PackageIconUrl>lice</PackageIconUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageReadMeFile>README.md</PackageReadMeFile>  
+    <Nullable>disable</Nullable>  
   </PropertyGroup>
 
   <ItemGroup>
     <Folder Include="Properties\" />
+    <None Include="README.md" Pack="True" PackagePath="\" />  
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
All Projects:
- Updated all target .NET 8 and .NET Framework 4.8 (These are the current LTS versions)
- Explicitly disabled Nullable property in all projects 

SampleWpfApplicationTests:
- Updated Tests to be STATestMethod to enable creation of MainWindow during tests for .NET 8
- Updated MS Test nuget packages to latest release (3.10.2)
- Added Microsoft.NET.Test.Sdk

WpfBindingErrors:
- Update .csproj properties
  - Updated PackageReleaseNotes text
  - Added PackageReadmeFile (dotnet build was producing a warning without it)

